### PR TITLE
Update import path for @vaadin/router in index.html to use jsDelivr CDN for improved module loading.

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       {
         "imports": {
           "lit": "https://unpkg.com/lit@3.2.0/index.js?module",
-          "@vaadin/router": "https://unpkg.com/@vaadin/router@2.0.2/dist/vaadin-router.js?module",
+          "@vaadin/router": "https://cdn.jsdelivr.net/npm/@vaadin/router@2.0.2/+esm",
           "@/": "./src/"
         }
       }


### PR DESCRIPTION
Update import path for @vaadin/router in index.html to use jsDelivr CDN for improved module loading.